### PR TITLE
Fix loading of test library

### DIFF
--- a/org-toodledo.el
+++ b/org-toodledo.el
@@ -2624,7 +2624,7 @@ lists."
   "Run only simulated org-toodledo tests."
   (interactive)
   (condition-case nil
-      (require 'org-toodledo-test)
+      (load-file "test/org-toodledo-test.el")
     (error (error "The file `org-toodledo-test` not available, download directly from source")))
   (org-toodledo-test 'sim))
 
@@ -2632,7 +2632,7 @@ lists."
   "Run org-toodledo-test suite."
   (interactive)
   (condition-case nil
-      (require 'org-toodledo-test)
+      (load-file "test/org-toodledo-test.el")
     (error (error "The file `org-toodledo-test` not available, download directly from source")))
   (when (y-or-n-p "Switch to test account and run org-toodledo tests? ")
     (let ((old-userid org-toodledo-userid)


### PR DESCRIPTION
Since there is a ".nosearch" file next to the test file, it won't be
on the `load-path` unless it was explicitly put there.  So instead of
using `require` load the file explicitly using `load-file`.